### PR TITLE
Beam logger dispatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,6 +317,9 @@ With this the two examples above will output the following:
 
 These are some future improvements currently on the road-map for the Glimt library.
 
+- [ ] Add overload protection for Actor dispatchers
+- [ ] Add support for writing custom erlang logger handlers
+    - Utilize overload protection
 - [ ] File-based config for setting log-levels of loggers based on name
     - Make it possible to override log-levels in libs by setting them in config file
 - [ ] File-dispatcher

--- a/README.md
+++ b/README.md
@@ -320,6 +320,7 @@ These are some future improvements currently on the road-map for the Glimt libra
 - [ ] Add overload protection for Actor dispatchers
 - [ ] Add support for writing custom erlang logger handlers
     - Utilize overload protection
+- [ ] Option to use basic formatters without color
 - [ ] File-based config for setting log-levels of loggers based on name
     - Make it possible to override log-levels in libs by setting them in config file
 - [ ] File-dispatcher

--- a/src/glimt/erlang_logger/basic_formatter.gleam
+++ b/src/glimt/erlang_logger/basic_formatter.gleam
@@ -17,6 +17,15 @@ import glimt/style.{
   style_trace, style_warning,
 }
 
+/// Set `basic_formatter` for erlang logger [handler](https://www.erlang.org/doc/apps/kernel/logger_chapter.html#handlers)
+/// with `handler_id`
+///
+/// Example:
+/// ```gleam
+/// use_with_handler("default")
+/// ```
+///
+/// Set basic Glimt formatting for the default handler (logger_std_h)
 pub fn use_with_handler(handler_id: String) {
   set_handler_config(
     a(handler_id),
@@ -25,6 +34,8 @@ pub fn use_with_handler(handler_id: String) {
   )
 }
 
+/// This is the callback that will be used by erlang logger to format
+/// log events. It is not intended to use directly.
 pub fn format(log_event: Dynamic, config: Dynamic) {
   case decode_log_event(log_event) {
     Ok(log_event) -> {
@@ -73,7 +84,7 @@ fn format_name_and_pid(logger_name: Option(String), pid: Pid) {
   }
 }
 
-pub fn style_level(log_level: Level) {
+fn style_level(log_level: Level) {
   case log_level {
     Emergency -> style_fatal()
     Alert -> style_fatal()

--- a/src/glimt/erlang_logger/basic_formatter.gleam
+++ b/src/glimt/erlang_logger/basic_formatter.gleam
@@ -1,0 +1,98 @@
+import gleam/io
+import gleam/list
+import gleam/string.{join} as gleam_string
+import gleam/dynamic.{Dynamic, from, string}
+import gleam/option.{None, Option, Some}
+import gleam/erlang
+import gleam/erlang/process.{Pid}
+import glimt/erlang_logger/common.{a, set_handler_config}
+import glimt/erlang_logger/level.{
+  Alert, Critical, Debug, Emergency, Error, Info, Level, Notice, Warning,
+}
+import glimt/erlang_logger/log_event.{Message, Report, decode_log_event}
+import glimt/style.{
+  style_debug, style_error, style_fatal, style_info, style_name, style_time,
+  style_trace, style_warning,
+}
+
+pub fn use_with_handler(handler_id: String) {
+  set_handler_config(
+    a(handler_id),
+    a("formatter"),
+    #(a("glimt@erlang_logger@basic_formatter"), dynamic.from(Nil)),
+  )
+}
+
+pub fn format(log_event: Dynamic, config: Dynamic) {
+  case decode_log_event(log_event) {
+    Ok(log_event) -> {
+      let styled_time = style_time(time_to_string(log_event.time_us))
+      let level_string = erlang.format(log_event.level)
+      let styled_level = style_level(log_event.level)(level_string)
+      let styled_name =
+        style_name(format_name_and_pid(log_event.logger_name, log_event.pid))
+      case log_event {
+        Message(message: message, ..) -> {
+          let styled_message = message
+          styled_time <> " | " <> styled_level <> " | " <> styled_name <> " | " <> styled_message <> "\n"
+        }
+        Report(report: report, ..) -> {
+          let styled_message = format_report(report)
+          styled_time <> " | " <> styled_level <> " | " <> styled_name <> " | " <> styled_message <> "\n"
+        }
+      }
+    }
+    _ -> {
+      io.println("Using build in format")
+      built_in_format(log_event, config)
+    }
+  }
+}
+
+fn format_report(report: List(#(Dynamic, Dynamic))) {
+  let report_content =
+    report
+    |> list.map(fn(entry) {
+      assert #(key, value) = entry
+      format_dynamic(key) <> " => " <> format_dynamic(value)
+    })
+    |> join(", ")
+  "(" <> report_content <> ")"
+}
+
+fn format_dynamic(dynamic_value: Dynamic) {
+  case string(dynamic_value) {
+    Ok(string_value) -> string_value
+    _ -> erlang.format(dynamic_value)
+  }
+}
+
+fn format_name_and_pid(logger_name: Option(String), pid: Pid) {
+  case logger_name {
+    Some(name) -> name <> "(" <> erlang.format(pid) <> ")"
+    None -> erlang.format(pid)
+  }
+}
+
+pub fn style_level(log_level: Level) {
+  case log_level {
+    Emergency -> style_fatal()
+    Alert -> style_fatal()
+    Critical -> style_fatal()
+    Error -> style_error()
+    Warning -> style_warning()
+    Notice -> style_info()
+    Info -> style_debug()
+    Debug -> style_trace()
+  }
+}
+
+fn time_to_string(time: Int) -> String {
+  system_time_to_rfc3339(time, from([#(a("unit"), a("microsecond"))]))
+}
+
+external fn system_time_to_rfc3339(time: Int, options: Dynamic) -> String =
+  "calendar" "system_time_to_rfc3339"
+
+external fn built_in_format(log_event: Dynamic, config: Dynamic) -> String =
+  "logger_formatter" "format"

--- a/src/glimt/erlang_logger/basic_formatter.gleam
+++ b/src/glimt/erlang_logger/basic_formatter.gleam
@@ -1,12 +1,12 @@
 import gleam/io
 import gleam/list
 import gleam/string.{join} as gleam_string
-import gleam/dynamic.{Dynamic, from}
+import gleam/dynamic.{Dynamic}
 import gleam/option.{None, Option, Some}
 import gleam/erlang
 import gleam/erlang/process.{Pid}
 import glimt/erlang_logger/common.{
-  a, built_in_format, format_dynamic, set_handler_config,
+  a, built_in_format, format_dynamic, set_handler_config, time_to_string,
 }
 import glimt/erlang_logger/level.{
   Alert, Critical, Debug, Emergency, Error, Info, Level, Notice, Warning,
@@ -33,14 +33,18 @@ pub fn format(log_event: Dynamic, config: Dynamic) {
       let styled_level = style_level(log_event.level)(level_string)
       let styled_name =
         style_name(format_name_and_pid(log_event.logger_name, log_event.pid))
+      let error_string = case log_event.error {
+        Some(error) -> " | " <> error
+        None -> ""
+      }
       case log_event {
         Message(message: message, ..) -> {
           let styled_message = message
-          styled_time <> " | " <> styled_level <> " | " <> styled_name <> " | " <> styled_message <> "\n"
+          styled_time <> " | " <> styled_level <> " | " <> styled_name <> " | " <> styled_message <> error_string <> "\n"
         }
         Report(report: report, ..) -> {
           let styled_message = format_report(report)
-          styled_time <> " | " <> styled_level <> " | " <> styled_name <> " | " <> styled_message <> "\n"
+          styled_time <> " | " <> styled_level <> " | " <> styled_name <> " | " <> styled_message <> error_string <> "\n"
         }
       }
     }
@@ -81,10 +85,3 @@ pub fn style_level(log_level: Level) {
     Debug -> style_trace()
   }
 }
-
-fn time_to_string(time: Int) -> String {
-  system_time_to_rfc3339(time, from([#(a("unit"), a("microsecond"))]))
-}
-
-external fn system_time_to_rfc3339(time: Int, options: Dynamic) -> String =
-  "calendar" "system_time_to_rfc3339"

--- a/src/glimt/erlang_logger/basic_formatter.gleam
+++ b/src/glimt/erlang_logger/basic_formatter.gleam
@@ -1,11 +1,13 @@
 import gleam/io
 import gleam/list
 import gleam/string.{join} as gleam_string
-import gleam/dynamic.{Dynamic, from, string}
+import gleam/dynamic.{Dynamic, from}
 import gleam/option.{None, Option, Some}
 import gleam/erlang
 import gleam/erlang/process.{Pid}
-import glimt/erlang_logger/common.{a, set_handler_config}
+import glimt/erlang_logger/common.{
+  a, built_in_format, format_dynamic, set_handler_config,
+}
 import glimt/erlang_logger/level.{
   Alert, Critical, Debug, Emergency, Error, Info, Level, Notice, Warning,
 }
@@ -60,13 +62,6 @@ fn format_report(report: List(#(Dynamic, Dynamic))) {
   "(" <> report_content <> ")"
 }
 
-fn format_dynamic(dynamic_value: Dynamic) {
-  case string(dynamic_value) {
-    Ok(string_value) -> string_value
-    _ -> erlang.format(dynamic_value)
-  }
-}
-
 fn format_name_and_pid(logger_name: Option(String), pid: Pid) {
   case logger_name {
     Some(name) -> name <> "(" <> erlang.format(pid) <> ")"
@@ -93,6 +88,3 @@ fn time_to_string(time: Int) -> String {
 
 external fn system_time_to_rfc3339(time: Int, options: Dynamic) -> String =
   "calendar" "system_time_to_rfc3339"
-
-external fn built_in_format(log_event: Dynamic, config: Dynamic) -> String =
-  "logger_formatter" "format"

--- a/src/glimt/erlang_logger/common.gleam
+++ b/src/glimt/erlang_logger/common.gleam
@@ -1,0 +1,13 @@
+import gleam/dynamic.{Dynamic}
+import gleam/erlang/atom.{Atom}
+
+pub fn a(string: String) -> Atom {
+  atom.create_from_string(string)
+}
+
+pub external fn set_handler_config(
+  handler_id: Atom,
+  config_item: Atom,
+  config: #(Atom, Dynamic),
+) -> Nil =
+  "logger" "set_handler_config"

--- a/src/glimt/erlang_logger/common.gleam
+++ b/src/glimt/erlang_logger/common.gleam
@@ -1,8 +1,16 @@
-import gleam/dynamic.{Dynamic}
+import gleam/dynamic.{Dynamic, string}
+import gleam/erlang
 import gleam/erlang/atom.{Atom}
 
 pub fn a(string: String) -> Atom {
   atom.create_from_string(string)
+}
+
+pub fn format_dynamic(dynamic_value: Dynamic) {
+  case string(dynamic_value) {
+    Ok(string_value) -> string_value
+    _ -> erlang.format(dynamic_value)
+  }
 }
 
 pub external fn set_handler_config(
@@ -11,3 +19,6 @@ pub external fn set_handler_config(
   config: #(Atom, Dynamic),
 ) -> Nil =
   "logger" "set_handler_config"
+
+pub external fn built_in_format(log_event: Dynamic, config: Dynamic) -> String =
+  "logger_formatter" "format"

--- a/src/glimt/erlang_logger/common.gleam
+++ b/src/glimt/erlang_logger/common.gleam
@@ -31,7 +31,12 @@ pub external fn set_handler_config(
 
 /// Calls the standard erlang formatter. Useful when a formatter is unable to
 /// format the log_event
-pub external fn built_in_format(log_event: Dynamic, config: Dynamic) -> String =
+pub fn built_in_format(log_event: Dynamic, config: Dynamic) -> String {
+  logger_format(log_event, config)
+  |> to_string()
+}
+
+pub external fn logger_format(log_event: Dynamic, config: Dynamic) -> Charlist =
   "logger_formatter" "format"
 
 /// Converts a epoch microsecond value to a rfc3339 string

--- a/src/glimt/erlang_logger/common.gleam
+++ b/src/glimt/erlang_logger/common.gleam
@@ -41,7 +41,10 @@ pub external fn logger_format(log_event: Dynamic, config: Dynamic) -> Charlist =
 
 /// Converts a epoch microsecond value to a rfc3339 string
 pub fn time_to_string(time: Int) -> String {
-  system_time_to_rfc3339(time, from([#(a("unit"), a("microsecond"))]))
+  system_time_to_rfc3339(
+    time,
+    from([#(a("unit"), from(a("microsecond"))), #(a("offset"), from(0))]),
+  )
   |> to_string()
 }
 

--- a/src/glimt/erlang_logger/common.gleam
+++ b/src/glimt/erlang_logger/common.gleam
@@ -1,6 +1,7 @@
-import gleam/dynamic.{Dynamic, string}
+import gleam/dynamic.{Dynamic, from, string}
 import gleam/erlang
 import gleam/erlang/atom.{Atom}
+import gleam/erlang/charlist.{Charlist, to_string}
 
 pub fn a(string: String) -> Atom {
   atom.create_from_string(string)
@@ -22,3 +23,11 @@ pub external fn set_handler_config(
 
 pub external fn built_in_format(log_event: Dynamic, config: Dynamic) -> String =
   "logger_formatter" "format"
+
+pub fn time_to_string(time: Int) -> String {
+  system_time_to_rfc3339(time, from([#(a("unit"), a("microsecond"))]))
+  |> to_string()
+}
+
+external fn system_time_to_rfc3339(time: Int, options: Dynamic) -> Charlist =
+  "calendar" "system_time_to_rfc3339"

--- a/src/glimt/erlang_logger/common.gleam
+++ b/src/glimt/erlang_logger/common.gleam
@@ -1,19 +1,27 @@
+//// Common functions used by the `logger`, `basic_formatter` and `json_formatter`
+
 import gleam/dynamic.{Dynamic, from, string}
 import gleam/erlang
 import gleam/erlang/atom.{Atom}
 import gleam/erlang/charlist.{Charlist, to_string}
 
+/// Shorthand for creating an `Atom`
+/// Equivalent to `atom.create_from_string()`
 pub fn a(string: String) -> Atom {
   atom.create_from_string(string)
 }
 
-pub fn format_dynamic(dynamic_value: Dynamic) {
+/// String representation of a `Dynamic` value.
+/// If the dynamic value is a String it will be returned, otherwise the value
+/// will be converted using `erlang.format`
+pub fn format_dynamic(dynamic_value: Dynamic) -> String {
   case string(dynamic_value) {
     Ok(string_value) -> string_value
     _ -> erlang.format(dynamic_value)
   }
 }
 
+/// Set config for handler with `handler_id`
 pub external fn set_handler_config(
   handler_id: Atom,
   config_item: Atom,
@@ -21,9 +29,12 @@ pub external fn set_handler_config(
 ) -> Nil =
   "logger" "set_handler_config"
 
+/// Calls the standard erlang formatter. Useful when a formatter is unable to
+/// format the log_event
 pub external fn built_in_format(log_event: Dynamic, config: Dynamic) -> String =
   "logger_formatter" "format"
 
+/// Converts a epoch microsecond value to a rfc3339 string
 pub fn time_to_string(time: Int) -> String {
   system_time_to_rfc3339(time, from([#(a("unit"), a("microsecond"))]))
   |> to_string()

--- a/src/glimt/erlang_logger/json_formatter.gleam
+++ b/src/glimt/erlang_logger/json_formatter.gleam
@@ -1,0 +1,39 @@
+import gleam/io
+import gleam/list.{append, map}
+import gleam/dynamic.{Dynamic}
+import gleam/json.{int, object, string}
+import glimt/erlang_logger/log_event.{Message, Report, decode_log_event}
+import glimt/erlang_logger/common.{
+  a, built_in_format, format_dynamic, set_handler_config,
+}
+
+pub fn use_with_handler(handler_id: String) {
+  set_handler_config(
+    a(handler_id),
+    a("formatter"),
+    #(a("glimt@erlang_logger@json_formatter"), dynamic.from(Nil)),
+  )
+}
+
+pub fn format(log_event: Dynamic, config: Dynamic) {
+  case decode_log_event(log_event) {
+    Ok(log_event) -> {
+      let common_json_fields = [#("time", int(log_event.time_us))]
+      let specific_json_fields = case log_event {
+        Message(message: message, ..) -> [#("message", string(message))]
+        Report(report: report, ..) ->
+          report
+          |> map(fn(entry) {
+            assert #(key, value) = entry
+            #(format_dynamic(key), string(format_dynamic(value)))
+          })
+      }
+      object(append(common_json_fields, specific_json_fields))
+      |> json.to_string() <> "\n"
+    }
+    _ -> {
+      io.println("Using build in format")
+      built_in_format(log_event, config)
+    }
+  }
+}

--- a/src/glimt/erlang_logger/json_formatter.gleam
+++ b/src/glimt/erlang_logger/json_formatter.gleam
@@ -1,10 +1,11 @@
 import gleam/io
 import gleam/list.{append, map}
+import gleam/option.{Some}
 import gleam/dynamic.{Dynamic}
 import gleam/json.{int, object, string}
 import glimt/erlang_logger/log_event.{Message, Report, decode_log_event}
 import glimt/erlang_logger/common.{
-  a, built_in_format, format_dynamic, set_handler_config,
+  a, built_in_format, format_dynamic, set_handler_config, time_to_string,
 }
 
 pub fn use_with_handler(handler_id: String) {
@@ -18,7 +19,10 @@ pub fn use_with_handler(handler_id: String) {
 pub fn format(log_event: Dynamic, config: Dynamic) {
   case decode_log_event(log_event) {
     Ok(log_event) -> {
-      let common_json_fields = [#("time", int(log_event.time_us))]
+      let common_json_fields = [
+        #("time", int(log_event.time_us)),
+        #("time_string", string(time_to_string(log_event.time_us))),
+      ]
       let specific_json_fields = case log_event {
         Message(message: message, ..) -> [#("message", string(message))]
         Report(report: report, ..) ->
@@ -28,7 +32,12 @@ pub fn format(log_event: Dynamic, config: Dynamic) {
             #(format_dynamic(key), string(format_dynamic(value)))
           })
       }
-      object(append(common_json_fields, specific_json_fields))
+      let report_json_fields = append(common_json_fields, specific_json_fields)
+      let json_fields_with_error = case log_event.error {
+        Some(error) -> [#("error", string(error)), ..report_json_fields]
+        _ -> report_json_fields
+      }
+      object(json_fields_with_error)
       |> json.to_string() <> "\n"
     }
     _ -> {

--- a/src/glimt/erlang_logger/json_formatter.gleam
+++ b/src/glimt/erlang_logger/json_formatter.gleam
@@ -8,6 +8,15 @@ import glimt/erlang_logger/common.{
   a, built_in_format, format_dynamic, set_handler_config, time_to_string,
 }
 
+/// Set `json_formatter` for erlang logger [handler](https://www.erlang.org/doc/apps/kernel/logger_chapter.html#handlers)
+/// with `handler_id`
+///
+/// Example:
+/// ```gleam
+/// use_with_handler("default")
+/// ```
+///
+/// Set basic Glimt formatting for the default handler (logger_std_h)
 pub fn use_with_handler(handler_id: String) {
   set_handler_config(
     a(handler_id),
@@ -16,6 +25,8 @@ pub fn use_with_handler(handler_id: String) {
   )
 }
 
+/// This is the callback that will be used by erlang logger to format
+/// log events. It is not intended to use directly.
 pub fn format(log_event: Dynamic, config: Dynamic) {
   case decode_log_event(log_event) {
     Ok(log_event) -> {

--- a/src/glimt/erlang_logger/level.gleam
+++ b/src/glimt/erlang_logger/level.gleam
@@ -1,0 +1,41 @@
+/// system is unusable
+pub external type Emergency
+
+/// action must be taken immediately
+pub external type Alert
+
+/// critical conditions
+pub external type Critical
+
+/// error conditions
+pub external type Error
+
+/// warning conditions
+pub external type Warning
+
+/// normal but significant conditions
+pub external type Notice
+
+/// informational messages
+pub external type Info
+
+/// debug-level messages
+pub external type Debug
+
+/// all levels
+pub external type All
+
+/// No level
+pub external type None
+
+/// Logger levels valid list
+pub type Level {
+  Emergency
+  Alert
+  Critical
+  Error
+  Warning
+  Notice
+  Info
+  Debug
+}

--- a/src/glimt/erlang_logger/level.gleam
+++ b/src/glimt/erlang_logger/level.gleam
@@ -1,34 +1,4 @@
-/// system is unusable
-pub external type Emergency
-
-/// action must be taken immediately
-pub external type Alert
-
-/// critical conditions
-pub external type Critical
-
-/// error conditions
-pub external type Error
-
-/// warning conditions
-pub external type Warning
-
-/// normal but significant conditions
-pub external type Notice
-
-/// informational messages
-pub external type Info
-
-/// debug-level messages
-pub external type Debug
-
-/// all levels
-pub external type All
-
-/// No level
-pub external type None
-
-/// Logger levels valid list
+/// Erlang logger levels
 pub type Level {
   Emergency
   Alert

--- a/src/glimt/erlang_logger/log_event.gleam
+++ b/src/glimt/erlang_logger/log_event.gleam
@@ -8,6 +8,7 @@ import gleam/dynamic.{
 import gleam/erlang/process.{Pid}
 import gleam/erlang/atom
 
+/// Gleam representation of an erlang log event
 pub type LogEvent {
   Message(
     time_us: Int,
@@ -27,6 +28,8 @@ pub type LogEvent {
   )
 }
 
+/// Translate a log event from erlang logger to corresponding gleam representation
+/// This function is useful when implementing custom formatters for the erlang logger
 pub fn decode_log_event(
   log_event: Dynamic,
 ) -> Result(LogEvent, List(DecodeError)) {

--- a/src/glimt/erlang_logger/log_event.gleam
+++ b/src/glimt/erlang_logger/log_event.gleam
@@ -1,0 +1,79 @@
+import glimt/erlang_logger/level.{Level}
+import glimt/erlang_logger/common.{a}
+import gleam/option.{None, Option, Some}
+import gleam/map
+import gleam/dynamic.{
+  DecodeError, Dynamic, dynamic, element, field, int, string, unsafe_coerce,
+}
+import gleam/erlang/process.{Pid}
+import gleam/erlang/atom
+
+pub type LogEvent {
+  Message(
+    time_us: Int,
+    level: Level,
+    message: String,
+    pid: Pid,
+    logger_name: Option(String),
+  )
+  Report(
+    time_us: Int,
+    level: Level,
+    report: List(#(Dynamic, Dynamic)),
+    pid: Pid,
+    logger_name: Option(String),
+  )
+}
+
+pub fn decode_log_event(
+  log_event: Dynamic,
+) -> Result(LogEvent, List(DecodeError)) {
+  try meta = field(a("meta"), dynamic)(log_event)
+  try time = field(a("time"), int)(meta)
+  try pid = field(a("pid"), dynamic)(meta)
+  let logger_name = case field(a("loggername"), string)(meta) {
+    Ok(name) -> Some(name)
+    _ -> None
+  }
+  try level = field(a("level"), dynamic)(log_event)
+  try msg = field(a("msg"), dynamic)(log_event)
+  try msg_type = element(0, dynamic)(msg)
+  try msg_type_atom = atom.from_dynamic(msg_type)
+  case atom.to_string(msg_type_atom) {
+    "string" -> {
+      try message = element(1, string)(msg)
+      Ok(Message(
+        time,
+        unsafe_coerce(level),
+        message,
+        unsafe_coerce(pid),
+        logger_name,
+      ))
+    }
+
+    "report" -> {
+      try report = element(1, dynamic)(msg)
+      Ok(Report(
+        time,
+        unsafe_coerce(level),
+        report_as_list(report),
+        unsafe_coerce(pid),
+        logger_name,
+      ))
+    }
+  }
+}
+
+fn report_as_list(report: Dynamic) {
+  let list_result = dynamic.list(dynamic.tuple2(dynamic, dynamic))(report)
+  case list_result {
+    Ok(list) -> list
+    _ -> {
+      let map_result = dynamic.map(dynamic, dynamic)(report)
+      case map_result {
+        Ok(map_report) -> map.to_list(map_report)
+        _ -> []
+      }
+    }
+  }
+}

--- a/src/glimt/erlang_logger/log_event.gleam
+++ b/src/glimt/erlang_logger/log_event.gleam
@@ -15,6 +15,7 @@ pub type LogEvent {
     message: String,
     pid: Pid,
     logger_name: Option(String),
+    error: Option(String),
   )
   Report(
     time_us: Int,
@@ -22,6 +23,7 @@ pub type LogEvent {
     report: List(#(Dynamic, Dynamic)),
     pid: Pid,
     logger_name: Option(String),
+    error: Option(String),
   )
 }
 
@@ -33,6 +35,10 @@ pub fn decode_log_event(
   try pid = field(a("pid"), dynamic)(meta)
   let logger_name = case field(a("loggername"), string)(meta) {
     Ok(name) -> Some(name)
+    _ -> None
+  }
+  let error = case field(a("error"), string)(meta) {
+    Ok(error) -> Some(error)
     _ -> None
   }
   try level = field(a("level"), dynamic)(log_event)
@@ -48,6 +54,7 @@ pub fn decode_log_event(
         message,
         unsafe_coerce(pid),
         logger_name,
+        error,
       ))
     }
 
@@ -59,6 +66,7 @@ pub fn decode_log_event(
         report_as_list(report),
         unsafe_coerce(pid),
         logger_name,
+        error,
       ))
     }
   }

--- a/src/glimt/erlang_logger/logger.gleam
+++ b/src/glimt/erlang_logger/logger.gleam
@@ -1,5 +1,7 @@
-import gleam/dynamic.{Dynamic}
+import gleam/dynamic.{Dynamic, from}
+import gleam/list.{append, map}
 import gleam/map.{Map}
+import gleam/option.{Option, Some}
 import glimt/log_message.{
   ALL, DEBUG, ERROR, FATAL, INFO, LogLevel, LogMessage, NONE, TRACE, WARNING,
 }
@@ -15,6 +17,36 @@ pub fn logger_dispatch(log_message: LogMessage(data, context, result_type)) {
   )
 }
 
+pub fn logger_report_dispatch(
+  log_message: LogMessage(
+    List(#(String, String)),
+    List(#(String, String)),
+    result_type,
+  ),
+) {
+  let data_report = as_report_list(log_message.data)
+  let context_report = as_report_list(log_message.context)
+  let combined_report = append(data_report, context_report)
+  let report = [#(a("msg"), from(log_message.message)), ..combined_report]
+  logger_log_report(
+    map_level(log_message.level),
+    map.from_list(report),
+    map.from_list([#(a("loggername"), from(log_message.name))]),
+  )
+}
+
+fn as_report_list(data: Option(List(#(String, String)))) {
+  case data {
+    Some(data) ->
+      data
+      |> map(fn(entry) {
+        assert #(key, value) = entry
+        #(a(key), from(value))
+      })
+    _ -> []
+  }
+}
+
 fn map_level(log_level: LogLevel) -> Level {
   case log_level {
     NONE -> Debug
@@ -28,7 +60,11 @@ fn map_level(log_level: LogLevel) -> Level {
   }
 }
 
-pub external fn logger_log_report(Level, Map(Atom, Dynamic)) -> Nil =
+pub external fn logger_log_report(
+  Level,
+  Map(Atom, Dynamic),
+  Map(Atom, Dynamic),
+) -> Nil =
   "logger" "log"
 
 external fn logger_log_message(Level, String, Map(Atom, String)) -> Nil =

--- a/src/glimt/erlang_logger/logger.gleam
+++ b/src/glimt/erlang_logger/logger.gleam
@@ -1,0 +1,35 @@
+import gleam/dynamic.{Dynamic}
+import gleam/map.{Map}
+import glimt/log_message.{
+  ALL, DEBUG, ERROR, FATAL, INFO, LogLevel, LogMessage, NONE, TRACE, WARNING,
+}
+import glimt/erlang_logger/level.{Critical, Debug, Info, Level, Notice, Warning}
+import glimt/erlang_logger/common.{a}
+import gleam/erlang/atom.{Atom}
+
+pub fn logger_dispatch(log_message: LogMessage(data, context, result_type)) {
+  logger_log_message(
+    map_level(log_message.level),
+    log_message.message,
+    map.from_list([#(a("loggername"), log_message.name)]),
+  )
+}
+
+fn map_level(log_level: LogLevel) -> Level {
+  case log_level {
+    NONE -> Debug
+    ALL -> Debug
+    TRACE -> Debug
+    DEBUG -> Info
+    INFO -> Notice
+    WARNING -> Warning
+    ERROR -> level.Error
+    FATAL -> Critical
+  }
+}
+
+pub external fn logger_log_report(Level, Map(Atom, Dynamic)) -> Nil =
+  "logger" "log"
+
+external fn logger_log_message(Level, String, Map(Atom, String)) -> Nil =
+  "logger" "log"

--- a/src/glimt/erlang_logger/logger.gleam
+++ b/src/glimt/erlang_logger/logger.gleam
@@ -10,6 +10,8 @@ import glimt/erlang_logger/level.{Critical, Debug, Info, Level, Notice, Warning}
 import glimt/erlang_logger/common.{a}
 import gleam/erlang/atom.{Atom}
 
+/// Dispatcher that send the `LogMessage` to the erlang built-in logger
+/// Logs the message as a string
 pub fn logger_dispatch(log_message: LogMessage(data, context, Dynamic)) {
   logger_log_message(
     map_level(log_message.level),
@@ -18,6 +20,9 @@ pub fn logger_dispatch(log_message: LogMessage(data, context, Dynamic)) {
   )
 }
 
+/// Dispatcher that send the `LogMessage` to the erlang built-in logger
+/// Logs the message as `msg` field in a report
+/// Merges `data` and `context` into the report
 pub fn logger_report_dispatch(
   log_message: LogMessage(
     List(#(String, String)),

--- a/src/glimt/erlang_logger/logger.gleam
+++ b/src/glimt/erlang_logger/logger.gleam
@@ -70,7 +70,7 @@ fn map_level(log_level: LogLevel) -> Level {
   }
 }
 
-pub external fn logger_log_report(
+external fn logger_log_report(
   Level,
   Map(Atom, Dynamic),
   Map(Atom, Dynamic),

--- a/src/glimt/serializer/basic.gleam
+++ b/src/glimt/serializer/basic.gleam
@@ -7,9 +7,9 @@ import glimt/log_message.{
   ALL, DEBUG, ERROR, FATAL, INFO, LogLevel, LogMessage, NONE, TRACE, WARNING,
   level_string,
 }
-import galant.{
-  dim, magenta, open, placeholder, start_bold, start_cyan, start_dim,
-  start_green, start_red, start_yellow, to_string_styler,
+import glimt/style.{
+  style_debug, style_error, style_fatal, style_info, style_name, style_plain,
+  style_time, style_trace, style_warning,
 }
 
 pub fn level_symbol(log_level: LogLevel) {
@@ -25,56 +25,6 @@ pub fn level_symbol(log_level: LogLevel) {
   }
 }
 
-fn style_trace() {
-  open()
-  |> start_dim()
-  |> start_cyan()
-  |> placeholder()
-  |> to_string_styler()
-}
-
-fn style_debug() {
-  open()
-  |> start_cyan()
-  |> placeholder()
-  |> to_string_styler()
-}
-
-fn style_info() {
-  open()
-  |> start_green()
-  |> placeholder()
-  |> to_string_styler()
-}
-
-fn style_error() {
-  open()
-  |> start_red()
-  |> placeholder()
-  |> to_string_styler()
-}
-
-fn style_fatal() {
-  open()
-  |> start_bold()
-  |> start_red()
-  |> placeholder()
-  |> to_string_styler()
-}
-
-fn style_warning() {
-  open()
-  |> start_yellow()
-  |> placeholder()
-  |> to_string_styler()
-}
-
-fn style_plain() {
-  open()
-  |> placeholder()
-  |> to_string_styler()
-}
-
 fn style_level(log_level: LogLevel) {
   case log_level {
     ALL -> style_plain()
@@ -86,18 +36,6 @@ fn style_level(log_level: LogLevel) {
     FATAL -> style_fatal()
     NONE -> style_plain()
   }
-}
-
-fn style_name(name: String) {
-  open()
-  |> magenta(name)
-  |> galant.to_string()
-}
-
-fn style_time(time: String) {
-  open()
-  |> dim(time)
-  |> galant.to_string()
 }
 
 fn full_name(

--- a/src/glimt/style.gleam
+++ b/src/glimt/style.gleam
@@ -1,0 +1,66 @@
+import galant.{
+  dim, magenta, open, placeholder, start_bold, start_cyan, start_dim,
+  start_green, start_red, start_yellow, to_string_styler,
+}
+
+pub fn style_trace() {
+  open()
+  |> start_dim()
+  |> start_cyan()
+  |> placeholder()
+  |> to_string_styler()
+}
+
+pub fn style_debug() {
+  open()
+  |> start_cyan()
+  |> placeholder()
+  |> to_string_styler()
+}
+
+pub fn style_info() {
+  open()
+  |> start_green()
+  |> placeholder()
+  |> to_string_styler()
+}
+
+pub fn style_error() {
+  open()
+  |> start_red()
+  |> placeholder()
+  |> to_string_styler()
+}
+
+pub fn style_fatal() {
+  open()
+  |> start_bold()
+  |> start_red()
+  |> placeholder()
+  |> to_string_styler()
+}
+
+pub fn style_warning() {
+  open()
+  |> start_yellow()
+  |> placeholder()
+  |> to_string_styler()
+}
+
+pub fn style_plain() {
+  open()
+  |> placeholder()
+  |> to_string_styler()
+}
+
+pub fn style_name(name: String) {
+  open()
+  |> magenta(name)
+  |> galant.to_string()
+}
+
+pub fn style_time(time: String) {
+  open()
+  |> dim(time)
+  |> galant.to_string()
+}

--- a/test/glimt_test.gleam
+++ b/test/glimt_test.gleam
@@ -18,6 +18,7 @@ import glimt/serializer/json.{
 import glimt/dispatcher/stdout.{dispatcher}
 import glimt/erlang_logger/logger.{logger_dispatch}
 import glimt/erlang_logger/basic_formatter
+import glimt/erlang_logger/json_formatter
 import gleam/io
 import glimt/erlang_logger/level.{Notice}
 import gleam/map
@@ -195,7 +196,7 @@ fn examples() {
       logger_dispatch,
     ))
 
-  basic_formatter.use_with_handler("default")
+  json_formatter.use_with_handler("default")
   logger_logger
   |> fatal("Disptaching to erlang logger", Error("Someting went wrong"))
 

--- a/test/glimt_test.gleam
+++ b/test/glimt_test.gleam
@@ -1,5 +1,5 @@
 import gleeunit
-import gleam/option.{None}
+import gleam/option.{None, Some}
 import gleam/erlang/process
 import gleam/erlang.{start_arguments}
 import gleam/json as gjson
@@ -16,7 +16,13 @@ import glimt/serializer/json.{
   new_json_serializer,
 }
 import glimt/dispatcher/stdout.{dispatcher}
+import glimt/erlang_logger/logger.{logger_dispatch}
+import glimt/erlang_logger/basic_formatter
 import gleam/io
+import glimt/erlang_logger/level.{Notice}
+import gleam/map
+import gleam/dynamic
+import gleam/erlang/atom
 
 pub fn main() {
   case start_arguments() {
@@ -179,6 +185,27 @@ fn examples() {
 
   logger_with_request
   |> info("User successfully logged in")
+
+  let logger_logger =
+    new("logger_logger")
+    |> level(TRACE)
+    |> append_instance(Direct(
+      Some("logger_dispatch"),
+      level_value(TRACE),
+      logger_dispatch,
+    ))
+
+  basic_formatter.use_with_handler("default")
+  logger_logger
+  |> fatal("Disptaching to erlang logger", Error("Someting went wrong"))
+
+  logger.logger_log_report(
+    Notice,
+    map.from_list([
+      #(atom.create_from_string("apa"), dynamic.from("bepa")),
+      #(atom.create_from_string("cepa"), dynamic.from("depa")),
+    ]),
+  )
 
   process.sleep(200)
 }

--- a/test/glimt_test.gleam
+++ b/test/glimt_test.gleam
@@ -16,7 +16,7 @@ import glimt/serializer/json.{
   new_json_serializer,
 }
 import glimt/dispatcher/stdout.{dispatcher}
-import glimt/erlang_logger/logger.{logger_dispatch}
+import glimt/erlang_logger/logger.{logger_dispatch, logger_report_dispatch}
 import glimt/erlang_logger/basic_formatter
 import glimt/erlang_logger/json_formatter
 import gleam/io
@@ -196,9 +196,22 @@ fn examples() {
       logger_dispatch,
     ))
 
-  json_formatter.use_with_handler("default")
+  basic_formatter.use_with_handler("default")
   logger_logger
   |> fatal("Disptaching to erlang logger", Error("Someting went wrong"))
+
+  let report_logger =
+    new("report_logger")
+    |> level(TRACE)
+    |> append_instance(Direct(
+      Some("logger_dispatch"),
+      level_value(TRACE),
+      logger_report_dispatch,
+    ))
+
+  report_logger
+  |> with_context([#("test", "report"), #("other", "field")])
+  |> log_with_data(INFO, "Dispatching with report logger", [#("data", "field")])
 
   logger.logger_log_report(
     Notice,
@@ -206,6 +219,7 @@ fn examples() {
       #(atom.create_from_string("apa"), dynamic.from("bepa")),
       #(atom.create_from_string("cepa"), dynamic.from("depa")),
     ]),
+    map.new(),
   )
 
   process.sleep(200)

--- a/test/glimt_test.gleam
+++ b/test/glimt_test.gleam
@@ -1,5 +1,6 @@
 import gleeunit
-import gleam/option.{None, Some}
+import gleeunit/should
+import gleam/option.{None}
 import gleam/erlang/process
 import gleam/erlang.{start_arguments}
 import gleam/json as gjson
@@ -16,14 +17,16 @@ import glimt/serializer/json.{
   new_json_serializer,
 }
 import glimt/dispatcher/stdout.{dispatcher}
+import glimt/erlang_logger/common.{a}
+import glimt/erlang_logger/level.{Notice}
 import glimt/erlang_logger/logger.{logger_dispatch, logger_report_dispatch}
 import glimt/erlang_logger/basic_formatter
 import glimt/erlang_logger/json_formatter
 import gleam/io
-import glimt/erlang_logger/level.{Notice}
 import gleam/map
+import gleam/string
 import gleam/dynamic
-import gleam/erlang/atom
+import gleam/erlang/charlist.{Charlist}
 
 pub fn main() {
   case start_arguments() {
@@ -40,6 +43,64 @@ pub fn main() {
 
 pub fn examples_test() {
   examples()
+}
+
+pub fn basic_formatter_minimal_test() {
+  basic_formatter.format(
+    dynamic.from(map.from_list([
+      #(a("level"), dynamic.from(Notice)),
+      #(a("msg"), dynamic.from(#(a("string"), "Test"))),
+      #(a("meta"), dynamic.from(map.from_list([]))),
+    ])),
+    dynamic.from(map.new()),
+  )
+  |> string.trim()
+  |> should.equal("notice: Test")
+}
+
+pub fn basic_formatter_unsupported_msg_type_test() {
+  basic_formatter.format(
+    dynamic.from(map.from_list([
+      #(a("level"), dynamic.from(Notice)),
+      #(a("msg"), dynamic.from(#("Test ~s ~s", ["some", "terms"]))),
+      #(a("meta"), dynamic.from(map.from_list([]))),
+    ])),
+    dynamic.from(map.new()),
+  )
+  |> string.trim()
+  |> should.equal("notice: Test some terms")
+}
+
+pub fn basic_formatter_list_report_test() {
+  basic_formatter.format(
+    dynamic.from(map.from_list([
+      #(a("level"), dynamic.from(Notice)),
+      #(
+        a("msg"),
+        dynamic.from(#(
+          a("report"),
+          [#(a("field1"), "value1"), #(a("field2"), "value2")],
+        )),
+      ),
+      #(
+        a("meta"),
+        dynamic.from(map.from_list([
+          #(
+            a("time"),
+            dynamic.from(time_ms_from_string(charlist.from_string(
+              "2023-01-06T17:14:42.640870+01:00",
+            ))),
+          ),
+          #(a("pid"), dynamic.from("<0.93.0>")),
+        ])),
+      ),
+    ])),
+    dynamic.from(map.new()),
+  )
+  |> string.trim()
+  |> should.equal(
+    "\e[2m2023-01-06T17:14:42.640870+01:00\e[22m\e[0m | \e[32mnotice\e[0m | \e[35m<<\"<0.93.0>\">>\e[39m\e[0m | (field1 => value1, field2 => value2)",
+  )
 }
 
 type Data {
@@ -246,3 +307,10 @@ fn examples() {
   )
   process.sleep(200)
 }
+
+fn time_ms_from_string(date_time: Charlist) {
+  rfc3339_to_system_time(date_time, [#(a("unit"), a("microsecond"))])
+}
+
+external fn rfc3339_to_system_time(date_time, options) -> Int =
+  "calendar" "rfc3339_to_system_time"

--- a/test/glimt_test.gleam
+++ b/test/glimt_test.gleam
@@ -99,7 +99,7 @@ pub fn basic_formatter_list_report_test() {
   )
   |> string.trim()
   |> should.equal(
-    "\e[2m2023-01-06T17:14:42.640870+01:00\e[22m\e[0m | \e[32mnotice\e[0m | \e[35m<<\"<0.93.0>\">>\e[39m\e[0m | (field1 => value1, field2 => value2)",
+    "\e[2m2023-01-06T16:14:42.640870+00:00\e[22m\e[0m | \e[32mnotice\e[0m | \e[35m<<\"<0.93.0>\">>\e[39m\e[0m | (field1 => value1, field2 => value2)",
   )
 }
 

--- a/test/glimt_test.gleam
+++ b/test/glimt_test.gleam
@@ -190,37 +190,59 @@ fn examples() {
   let logger_logger =
     new("logger_logger")
     |> level(TRACE)
-    |> append_instance(Direct(
-      Some("logger_dispatch"),
-      level_value(TRACE),
-      logger_dispatch,
-    ))
+    |> append_instance(Direct(None, level_value(TRACE), logger_dispatch))
 
-  json_formatter.use_with_handler("default")
+  basic_formatter.use_with_handler("default")
   logger_logger
-  |> fatal("Dispatching to erlang logger", Error("Something went wrong"))
+  |> error(
+    "Could not connect to database",
+    Error("Connection timeout: 127:0.0.1:5432"),
+  )
 
   let report_logger =
     new("report_logger")
     |> level(TRACE)
-    |> append_instance(Direct(
-      Some("logger_dispatch"),
-      level_value(TRACE),
-      logger_report_dispatch,
-    ))
+    |> append_instance(Direct(None, level_value(TRACE), logger_report_dispatch))
 
   report_logger
-  |> with_context([#("test", "report"), #("other", "field")])
-  |> log_with_data(INFO, "Dispatching with report logger", [#("data", "field")])
-
-  logger.logger_log_report(
-    Notice,
-    map.from_list([
-      #(atom.create_from_string("apa"), dynamic.from("bepa")),
-      #(atom.create_from_string("cepa"), dynamic.from("depa")),
-    ]),
-    map.new(),
+  |> with_context([
+    #("host", "blue-panda.fly.dev"),
+    #("url", "users"),
+    #("params", "token=48dhf8h826ad876f78&"),
+  ])
+  |> log_with_data(
+    INFO,
+    "Successfully fetched user data",
+    [#("username", "JohnBjrk"), #("github_url", "https://github.com/JohnBjrk")],
   )
 
+  let logger_logger =
+    new("logger_logger")
+    |> level(TRACE)
+    |> append_instance(Direct(None, level_value(TRACE), logger_dispatch))
+
+  json_formatter.use_with_handler("default")
+  logger_logger
+  |> error(
+    "Could not connect to database",
+    Error("Connection timeout: 127:0.0.1:5432"),
+  )
+
+  let report_logger =
+    new("report_logger")
+    |> level(TRACE)
+    |> append_instance(Direct(None, level_value(TRACE), logger_report_dispatch))
+
+  report_logger
+  |> with_context([
+    #("host", "blue-panda.fly.dev"),
+    #("url", "users"),
+    #("params", "token=48dhf8h826ad876f78&"),
+  ])
+  |> log_with_data(
+    INFO,
+    "Successfully fetched user data",
+    [#("username", "JohnBjrk"), #("github_url", "https://github.com/JohnBjrk")],
+  )
   process.sleep(200)
 }

--- a/test/glimt_test.gleam
+++ b/test/glimt_test.gleam
@@ -196,9 +196,9 @@ fn examples() {
       logger_dispatch,
     ))
 
-  basic_formatter.use_with_handler("default")
+  json_formatter.use_with_handler("default")
   logger_logger
-  |> fatal("Disptaching to erlang logger", Error("Someting went wrong"))
+  |> fatal("Dispatching to erlang logger", Error("Something went wrong"))
 
   let report_logger =
     new("report_logger")


### PR DESCRIPTION
Partially addressing #1. Added support for dispatching to BEAM logger and formatting the logs in a similar way as glimt native logs. Some more ideas on how to integrate with the BEAM logger added to README